### PR TITLE
Feat/12 change metadata output format

### DIFF
--- a/R/reexport_portfolio.R
+++ b/R/reexport_portfolio.R
@@ -71,17 +71,19 @@ reexport_portfolio <- function(
     logger::log_trace("Adding file information to portfolio metadata.")
     file_summary[["portfolios"]] <- portfolio_summary
 
+    # No warnings or errors detected
+    file_summary[["warnings"]] <- NULL
+    file_summary[["errors"]] <- NULL
+
   } else { # no portfolio data detected
 
     logger::log_warn("Cannot import file: ", input_filepath)
     warning("No portfolio data detected in file.")
-    file_summary[["error"]] <- list(
+    file_summary[["errors"]] <- list(
       "Cannot import portfolio file. Please see documentation."
     )
     file_summary[["warnings"]] <- NULL
-    file_summary[["group_cols"]] <- NULL
-    file_summary[["subportfolios_count"]] <- NULL
-    file_sumary[["portfolios"]] <- NULL
+    file_summary[["portfolios"]] <- NULL
   }
 
   logger::log_info("Finished processing file: ", input_filepath)

--- a/R/reexport_portfolio.R
+++ b/R/reexport_portfolio.R
@@ -29,13 +29,14 @@ reexport_portfolio <- function(
 
   file_summary <- list(
     input_filename = input_filename,
-    input_digest = input_digest,
-    input_entries = input_entries
+    input_digest = input_digest
   )
 
   # read_portfolio_csv retruns NA if it cannot process a portfolio
   if (inherits(portfolio_data, "data.frame")) {
     logger::log_trace("Portfolio data detected in file.")
+
+    file_summary[["input_entries"]] <- input_entries
 
     group_cols_possible <- c("portfolio_name", "investor_name")
     group_cols <- group_cols_possible[

--- a/R/reexport_portfolio.R
+++ b/R/reexport_portfolio.R
@@ -4,7 +4,7 @@ reexport_portfolio <- function(
   output_directory
 ) {
 
-  if (length(input_filepath) > 1) {
+  if (length(input_filepath) > 1L) {
     logger::log_error("Only one filepath can be processed at a time.")
     stop("Only one filepath can be processed at a time.")
   }
@@ -25,59 +25,65 @@ reexport_portfolio <- function(
     serialize = FALSE
   )
   input_filename <- basename(input_filepath)
-  input_entries <- nrow(portfolio_data)
+  input_entries <- nrow(portfolio_data) #returns NULL if no data
+
+  file_summary <- list(
+    input_filename = input_filename,
+    input_digest = input_digest,
+    input_entries = input_entries
+  )
 
   # read_portfolio_csv retruns NA if it cannot process a portfolio
-  if (!inherits(portfolio_data, "data.frame")) {
-    logger::log_warn("Cannot import file: ", input_filepath)
-    warning("No portfolio data detected in file.")
-    return(
-      list(
-        input_filename = input_filename,
-        input_digest = input_digest,
-        # TODO: provide mechanism for better messages
-        error = "Cannot import portfolio file. Please see documentation."
+  if (inherits(portfolio_data, "data.frame")) {
+    logger::log_trace("Portfolio data detected in file.")
+
+    group_cols_possible <- c("portfolio_name", "investor_name")
+    group_cols <- group_cols_possible[
+      group_cols_possible %in% names(portfolio_data)
+    ]
+    file_summary[["group_cols"]] <- group_cols
+
+    grouped_portfolios <- dplyr::group_by(
+      .data = portfolio_data,
+      dplyr::pick(dplyr::all_of(group_cols))
+    )
+    subportfolios_count <- nrow(dplyr::group_keys(grouped_portfolios))
+    logger::log_trace(subportfolios_count, " portfolios detected in file.")
+    file_summary[["subportfolios_count"]] <- subportfolios_count
+
+    if (length(group_cols) > 0L) {
+      logger::log_trace(
+        "Portfolio data grouped by ", length(group_cols), " cols"
+      )
+      logger::log_trace(toString(group_cols))
+    }
+
+    logger::log_trace("Exporting portfolio data.")
+    portfolio_summary <- dplyr::group_map(
+      .data = grouped_portfolios,
+      .f = ~ export_portfolio(
+        portfolio_data = .x,
+        group_data = .y,
+        output_directory = output_directory
       )
     )
-  }
 
-  group_cols_poss <- c("portfolio_name", "investor_name")
-  group_cols <- group_cols_poss[group_cols_poss %in% names(portfolio_data)]
+    logger::log_trace("Adding file information to portfolio metadata.")
+    file_summary[["portfolios"]] <- portfolio_summary
 
-  grouped_portfolios <- dplyr::group_by(
-    .data = portfolio_data,
-    dplyr::pick(dplyr::all_of(group_cols))
-  )
-  subportfolios_count <- nrow(dplyr::group_keys(grouped_portfolios))
-  logger::log_trace(subportfolios_count, " portfolios detected in file.")
-  if (length(group_cols) > 0) {
-    logger::log_trace("Portfolio data grouped by ", length(group_cols), " cols")
-    logger::log_trace(paste(group_cols, collapse = ", "))
-  }
+  } else { # no portfolio data detected
 
-  logger::log_trace("Exporting portfolio data.")
-  portfolio_summary <- dplyr::group_map(
-    .data = grouped_portfolios,
-    .f = ~ export_portfolio(
-      portfolio_data = .x,
-      group_data = .y,
-      output_directory = output_directory
+    logger::log_warn("Cannot import file: ", input_filepath)
+    warning("No portfolio data detected in file.")
+    file_summary[["error"]] <- list(
+      "Cannot import portfolio file. Please see documentation."
     )
-  )
-
-  logger::log_trace("Adding file information to portfolio metadata.")
-  full_portfolio_summary <- purrr::map(
-    .x = portfolio_summary,
-    .f = function(x) {
-      x[["input_digest"]] <- input_digest
-      x[["input_filename"]] <- input_filename
-      x[["input_entries"]] <- input_entries
-      x[["subportfolios_count"]] <- subportfolios_count
-      x[["group_cols"]] <- group_cols
-      return(x)
-    }
-  )
+    file_summary[["warnings"]] <- NULL
+    file_summary[["group_cols"]] <- NULL
+    file_summary[["subportfolios_count"]] <- NULL
+    file_sumary[["portfolios"]] <- NULL
+  }
 
   logger::log_info("Finished processing file: ", input_filepath)
-  return(full_portfolio_summary)
+  return(file_summary)
 }

--- a/tests/testthat/helper-simple_output.R
+++ b/tests/testthat/helper-simple_output.R
@@ -89,28 +89,58 @@ expect_simple_reexport <- function(
   input_entries
 ) {
   # check length of metadata
-  testthat::expect_equal(length(metadata), input_entries)
+  testthat::expect_setequal(
+    object = names(metadata),
+    expected = c(
+      "group_cols",
+      "input_digest",
+      "input_entries",
+      "input_filename",
+      "portfolios",
+      "subportfolios_count"
+    )
+  )
+
+  testthat::expect_null(metadata[["errors"]])
+  testthat::expect_setequal(metadata[["group_cols"]], colnames(groups))
+  testthat::expect_identical(metadata[["input_digest"]], input_digest)
+  testthat::expect_identical(metadata[["input_entries"]], input_entries)
+  testthat::expect_identical(metadata[["input_filename"]], input_filename)
+
+  testthat::expect_type(metadata[["portfolios"]], "list")
+  testthat::expect_length(
+    object = metadata[["portfolios"]],
+    n = metadata[["subportfolios_count"]]
+  )
+
+  testthat::expect_identical(metadata[["subportfolios_count"]], max(nrow(groups), 1L))
+
+  testthat::expect_null(metadata[["warnings"]])
+  testthat::expect_null(metadata[["errors"]])
 
   observed_groups <- groups[0, ]
   # for each entry in the metadata
-  for (x in metadata) {
+  for (x in metadata[["portfolios"]]) {
     # check that the output file exists
     output_filepath <- file.path(
       output_dir,
       x[["output_filename"]]
     )
     file_content_rows <- expect_simple_portfolio_file(output_filepath)
-    testthat::expect_equal(
+    testthat::expect_identical(
       x[["output_rows"]],
       file_content_rows
     )
 
     required_fields <- c(
-      "output_filename", "output_rows", "output_digest",
-      "input_digest", "input_filename", "input_entries",
-      "subportfolios_count", "group_cols"
+      "output_filename",
+      "output_rows",
+      "output_digest"
     )
-    optional_fields <- c("investor_name", "portfolio_name")
+    optional_fields <- c(
+      "investor_name",
+      "portfolio_name"
+    )
     testthat::expect_contains(names(x), required_fields)
     testthat::expect_in(
       names(x),
@@ -118,15 +148,7 @@ expect_simple_reexport <- function(
     )
 
     # check that the output file has the correct number of rows
-    testthat::expect_equal(x[["output_rows"]], 1L)
-    # check that the output file has the correct input digest
-    testthat::expect_equal(x[["input_digest"]], input_digest)
-    # check that the output file has the correct input filename
-    testthat::expect_equal(x[["input_filename"]], input_filename)
-    # check that the output file has the correct input entries
-    testthat::expect_equal(x[["input_entries"]], input_entries)
-    testthat::expect_equal(x[["subportfolios_count"]], max(nrow(groups), 1L))
-    testthat::expect_setequal(x[["group_cols"]], colnames(groups))
+    testthat::expect_identical(x[["output_rows"]], 1L)
 
     # check that the output file has the correct investor and portfolio names
     # look for this cobination in the groups data frame and add to observed
@@ -175,6 +197,7 @@ expect_simple_reexport <- function(
     }
     observed_groups <- dplyr::bind_rows(observed_groups, this_group)
   }
+  # Test that all observed groups are the expected groups
   testthat::expect_equal(
     dplyr::arrange(observed_groups, !!!rlang::syms(colnames(groups))),
     dplyr::arrange(groups, !!!rlang::syms(colnames(groups)))

--- a/tests/testthat/helper-simple_output.R
+++ b/tests/testthat/helper-simple_output.R
@@ -214,7 +214,9 @@ expect_reexport_failure <- function(
     list(
       input_filename = basename(input_filename),
       input_digest = input_digest,
-      error = "Cannot import portfolio file. Please see documentation."
+      errors = list(
+        "Cannot import portfolio file. Please see documentation."
+      )
     )
   )
 }

--- a/tests/testthat/test-process_directory.R
+++ b/tests/testthat/test-process_directory.R
@@ -38,7 +38,7 @@ test_that("Processing a directory with a single file works.", {
     groups = empty_groups,
     input_digest = filehash,
     input_filename = "foo.csv",
-    input_entries = 1
+    input_entries = 1L
   )
 })
 
@@ -75,7 +75,7 @@ test_that("Processing a directory with a multiple files works.", {
     groups = empty_groups,
     input_digest = filehash,
     input_filename = "foo1.csv",
-    input_entries = 1
+    input_entries = 1L
   )
   expect_simple_reexport(
     output_dir = output_dir,
@@ -83,6 +83,6 @@ test_that("Processing a directory with a multiple files works.", {
     groups = empty_groups,
     input_digest = filehash,
     input_filename = "foo2.csv",
-    input_entries = 1
+    input_entries = 1L
   )
 })

--- a/tests/testthat/test-reexport-columns.R
+++ b/tests/testthat/test-reexport-columns.R
@@ -27,7 +27,6 @@ files_to_test <- c(
 
 for (filename in files_to_test) {
   test_that(paste("re-exporting fails with missing columns -", filename), {
-skip()
     test_file <- testthat::test_path(
       "testdata", "portfolios", "columns", filename
     )

--- a/tests/testthat/test-reexport-columns.R
+++ b/tests/testthat/test-reexport-columns.R
@@ -27,6 +27,7 @@ files_to_test <- c(
 
 for (filename in files_to_test) {
   test_that(paste("re-exporting fails with missing columns -", filename), {
+skip()
     test_file <- testthat::test_path(
       "testdata", "portfolios", "columns", filename
     )

--- a/tests/testthat/test-reexport-headers.R
+++ b/tests/testthat/test-reexport-headers.R
@@ -48,7 +48,7 @@ for (filename in files_to_test) {
       groups = simple_groups,
       input_digest = filehash,
       input_filename = basename(test_file),
-      input_entries = 1
+      input_entries = 1L
     )
   })
 }

--- a/tests/testthat/test-reexport.R
+++ b/tests/testthat/test-reexport.R
@@ -32,7 +32,7 @@ test_that("re-exporting simple file works.", {
     groups = empty_groups,
     input_digest = filehash,
     input_filename = basename(test_file),
-    input_entries = 1
+    input_entries = 1L
   )
 })
 
@@ -55,7 +55,7 @@ test_that("re-exporting simple exported file yields same file.", {
     groups = empty_groups,
     input_digest = filehash,
     input_filename = basename(test_file),
-    input_entries = 1
+    input_entries = 1L
   )
 })
 
@@ -78,7 +78,7 @@ test_that("re-exporting simple file with all columns works", {
     groups = simple_groups,
     input_digest = filehash,
     input_filename = basename(test_file),
-    input_entries = 1
+    input_entries = 1L
   )
 })
 
@@ -127,6 +127,6 @@ test_that("re-exporting multiportfolio file with all columns works", {
     groups = groups,
     input_digest = filehash,
     input_filename = basename(test_file),
-    input_entries = 2
+    input_entries = 2L
   )
 })


### PR DESCRIPTION
Changes grain of output format of `reexport_portfolio()` from a list of exported portfolios, each of which includes information about the input file, to a list of information about the input file, which includes a list of exported subportfolios:

Previously (abbreviated example):
```r
list(
  list(
    portfolio_name = portfolio_name1
    input_filename = input_filename1
  ),
  list(
    portfolio_name = portfolio_name2
    input_filename = input_filename1
  ),
)
```

now:
```r
list(
  input_filename = input_filename1
  portfolios = list(
    list(
      portfolio_name = portfolio_name1
    ),
    list(
      portfolio_name = portfolio_name2
    )
  )
)
```

This serves the purpose of a consistent format for files that cannot be re-exported properly (pacta.portfolio.import::read_portfolio.csv()` returns `NA`), where the input file infromation can include error messages that can be surfaced to the user.

```r
list(
  list(
    input_filename = input_filename1
    portfolios = list(
      list(
        portfolio_name = portfolio_name1
      )
    )
  ),
  list(
    input_filename = input_filename2
    errors = list(
      "Some useful Error message"
    )
  )
)
```

Closes #12